### PR TITLE
add CMD trace #6

### DIFF
--- a/usr/local/libexec/rocinante/cmd.sh
+++ b/usr/local/libexec/rocinante/cmd.sh
@@ -32,13 +32,19 @@
 . /usr/local/etc/rocinante.conf
 
 cmd_usage() {
-    error_exit "Usage: rocinante cmd command"
+    error_exit "Usage: rocinante cmd [OPTION] command"
 }
+
+OPTION="-xc"
 
 # Handle special-case commands first.
 case "$1" in
 help|-h|--help)
     cmd_usage
+    ;;
+-q|--quiet)
+    OPTION="-c"
+    shift
     ;;
 esac
 
@@ -47,7 +53,8 @@ if [ $# -eq 0 ]; then
 fi
 
 ## execute CMD
-sh -c "$@"
+info "[CMD]:"
+sh "${OPTION}" "$@"
 ERROR_CODE="$?"
 info "${ERROR_CODE}"
 


### PR DESCRIPTION
option `-q` suppresses the output, on by default (like `cp -v`)

```
$ rocinante cmd "echo 'print me'"
[CMD]:
+ echo 'print me'
print me
0

$ rocinante cmd -q "echo 'print me'"
[CMD]:
print me
0

$ cat base/Bastillefile 
CMD /bin/ln -sf /usr/share/zoneinfo/Europe/Prague /etc/localtime

CP etc /
CP root /

$ rocinante template base/
[TEMPLATE]:
Applying template: base/...

[CMD]:
+ /bin/ln -sf /usr/share/zoneinfo/Europe/Prague /etc/localtime
0

[CP]:
base//etc -> /etc
base//etc/ttys -> /etc/ttys

[CP]:
base//root -> /root
base//root/.hushlogin -> /root/.hushlogin

Template applied: base/
```