### PR TITLE
Bail out if rocinante_templatesdir does not exist

### DIFF
--- a/usr/local/libexec/rocinante/list.sh
+++ b/usr/local/libexec/rocinante/list.sh
@@ -48,6 +48,6 @@ if [ $# -gt 0 ]; then
 fi
 
 if [ $# -eq 0 ]; then
-    cd ${rocinante_templatesdir}
+    cd ${rocinante_templatesdir} || error_exit
     find . -type d -maxdepth 2
 fi


### PR DESCRIPTION
else find would be run in the current directory.