### PR TITLE
Repaired git

### DIFF
--- a/usr/local/etc/rocinante.conf
+++ b/usr/local/etc/rocinante.conf
@@ -1,4 +1,5 @@
 rocinante_branches="main master"
+rocinante_default_branch="main"
 rocinante_libdir="/usr/local/libexec/rocinante"
 rocinante_prefix="/usr/local/rocinante"
 rocinante_templatesdir="/usr/local/rocinante/templates"

--- a/usr/local/libexec/rocinante/bootstrap.sh
+++ b/usr/local/libexec/rocinante/bootstrap.sh
@@ -73,6 +73,7 @@ fetch_template() {
     _url=${ROCINANTE_TEMPLATE_URL}
     _user=${ROCINANTE_TEMPLATE_USER}
     _repo=${ROCINANTE_TEMPLATE_REPO}
+    _branch=${ROCINANTE_TEMPLATE_BRANCH}
     _template=${rocinante_templatesdir}/${_user}/${_repo}
     _template_user=${rocinante_templatesdir}/${_user}
 
@@ -100,7 +101,7 @@ fetch_template() {
     else
         if [ ! -d "${_template}/.git" ]; then
             mkdir -p "${_template}/"
-            git clone "${_url}" "${_template}" || error_notify "Clone unsuccessful."
+            git clone --branch ${_branch} --single-branch "${_url}" "${_template}" || error_notify "Clone unsuccessful."
         elif [ -d "${_template}/.git" ]; then
             git -C "${_template}" pull ||\
             error_notify "Template update unsuccessful."
@@ -109,11 +110,19 @@ fetch_template() {
     fi
 }
 
-case "${1}" in
-http?://*/*/*)
-    ROCINANTE_TEMPLATE_URL=${1}
-    ROCINANTE_TEMPLATE_USER=$(echo "${1}" | awk -F / '{ print $4 }')
-    ROCINANTE_TEMPLATE_REPO=$(echo "${1}" | awk -F / '{ print $5 }')
-    fetch_template
-    ;;
+if [ $# -lt 1 ]
+  error_exit "Usage: rocinante bootstrap <template_url> [branch]"
+fi
+
+ROCINANTE_TEMPLATE_URL=${1}
+shift
+ROCINANTE_TEMPLATE_BRANCH="${1:-$rocinance_default_branch}"
+
+
+case "${ROCINANTE_TEMPLATE_URL}" in
+    http?://*/*/*)
+        ROCINANTE_TEMPLATE_USER=$(echo "${1}" | awk -F / '{ print $4 }')
+        ROCINANTE_TEMPLATE_REPO=$(echo "${1}" | awk -F / '{ print $5 }')
+        fetch_template
+        ;;
 esac

--- a/usr/local/libexec/rocinante/bootstrap.sh
+++ b/usr/local/libexec/rocinante/bootstrap.sh
@@ -98,10 +98,11 @@ fetch_template() {
         #    rocinante verify "${_user}/${_repo}"
         #fi
     else
-        if [ ! -d "${rocinante_templatesdir}/.git" ]; then
-            git clone "${_url}" "${rocinante_templatesdir}" || error_notify "Clone unsuccessful."
-        elif [ -d "${rocinante_templatesdir}/.git" ]; then
-            git -C "${rocinante_templatesdir}" pull ||\
+        if [ ! -d "${_template}/.git" ]; then
+            mkdir -p "${_template}/"
+            git clone "${_url}" "${_template}" || error_notify "Clone unsuccessful."
+        elif [ -d "${_template}/.git" ]; then
+            git -C "${_template}" pull ||\
             error_notify "Template update unsuccessful."
         fi
         #rocinante verify "${_user}/${_repo}"


### PR DESCRIPTION
Hi there, 
  while trying to use rocinante I found first that the git repo is pulled into _/usr/local/rocinante/templates_ instead of _/usr/local/rocinante/templates/user/repository_, so I fixed this. 

Further I found, that there is no check whether any new commits have been done to origin although a pull mechanism is found in bootstrap.sh. So I implemented this check triggering another call to bootstrap if the local repo is behind origin.

I am not very familar with git, but still if I am able to dive deeper I would send another suggestion to set a custom name for the deployment branch used, instead of the generic _master_. 

Hope you'll find these 2 cents helpful :) 

KR
Benjamin