### PR TITLE
add support arbitrary args

### DIFF
--- a/usr/local/libexec/rocinante/sysctl.sh
+++ b/usr/local/libexec/rocinante/sysctl.sh
@@ -32,7 +32,7 @@
 . /usr/local/etc/rocinante.conf
 
 sysctl_usage() {
-    error_exit "Usage: rocinante sysctl key=value"
+    error_exit "Usage: rocinante sysctl key=value [args]"
 }
 
 # Handle special-case commands first.

--- a/usr/local/libexec/rocinante/update.sh
+++ b/usr/local/libexec/rocinante/update.sh
@@ -32,7 +32,7 @@
 . /usr/local/etc/rocinante.conf
 
 update_usage() {
-    error_exit "Usage: rocinante update"
+    error_exit "Usage: rocinante update [args]"
 }
 
 # Handle special-case commands first.
@@ -41,10 +41,6 @@ help|-h|--help)
     update_usage
     ;;
 esac
-
-if [ $# -gt 1 ]; then
-    update_usage
-fi
 
 if [ -f "/bin/midnightbsd-version" ]; then
     error_exit "Not yet supported on MidnightBSD."
@@ -55,5 +51,5 @@ if freebsd-version | grep -qi HBSD; then
 fi
 
 info "[UPDATE]:"
-PAGER="/bin/cat" freebsd-update fetch install --not-running-from-cron
+PAGER="/bin/cat" freebsd-update fetch install --not-running-from-cron "$@"
 echo -e "${COLOR_RESET}"

--- a/usr/local/libexec/rocinante/upgrade.sh
+++ b/usr/local/libexec/rocinante/upgrade.sh
@@ -32,7 +32,7 @@
 . /usr/local/etc/rocinante.conf
 
 upgrade_usage() {
-    error_exit "Usage: rocinante upgrade release"
+    error_exit "Usage: rocinante upgrade release [args]"
 }
 
 # Handle special-case commands first.
@@ -41,10 +41,6 @@ help|-h|--help)
     upgrade_usage
     ;;
 esac
-
-if [ $# -gt 1 ]; then
-    upgrade_usage
-fi
 
 if [ -f "/bin/midnightbsd-version" ]; then
     error_exit "Not yet supported on MidnightBSD."
@@ -56,5 +52,5 @@ fi
 
 ## execute UPGRADE
 info "[UPGRADE]:"
-PAGER="/bin/cat" freebsd-update upgrade -r $@
+PAGER="/bin/cat" freebsd-update upgrade -r "$@"
 echo -e "${COLOR_RESET}"


### PR DESCRIPTION
Assuming the default: `basedir /`. From `man freebsd-update`:

```
     -b basedir     Operate on a system mounted at basedir.  (default: /, or
                    as given in the configuration file.)
```

On systems where `/etc/freebsd-update.conf` overrides the `basedir,` this changes the default behavior.