### PR TITLE
Support git URLs in bootstrap

### DIFF
--- a/usr/local/libexec/rocinante/bootstrap.sh
+++ b/usr/local/libexec/rocinante/bootstrap.sh
@@ -115,4 +115,11 @@ http?://*/*/*)
     ROCINANTE_TEMPLATE_REPO=$(echo "${1}" | awk -F / '{ print $5 }')
     fetch_template
     ;;
+git@*:*/*)
+    ROCINANTE_TEMPLATE_URL=${1}
+    git_repository=$(echo "${1}" | awk -F : '{ print $2 }')
+    ROCINANTE_TEMPLATE_USER=$(echo "${git_repository}" | awk -F / '{ print $1 }')
+    ROCINANTE_TEMPLATE_REPO=$(echo "${git_repository}" | awk -F / '{ print $2 }')
+    fetch_template
+    ;;
 esac


### PR DESCRIPTION
This change adds git URLs to bootstrap, making it easy to use private github repos.