### PR TITLE
Fix usage help text in bootstrap.sh

### DIFF
--- a/usr/local/libexec/rocinante/bootstrap.sh
+++ b/usr/local/libexec/rocinante/bootstrap.sh
@@ -38,7 +38,7 @@ bootstrap_usage() {
 while [ "$#" -gt 0 ]; do
     case "${1}" in
         -h|--help|help)
-            cmd_usage
+            bootstrap_usage
             ;;
         -x|--debug)
             enable_debug


### PR DESCRIPTION
The -h option referred to a nonexistent cmd_usage rather than bootstrap_usage.