### PR TITLE
Fix usage help fuctions

### DIFF
--- a/usr/local/libexec/rocinante/template.sh
+++ b/usr/local/libexec/rocinante/template.sh
@@ -130,7 +130,7 @@ line_in_file() {
 while [ "$#" -gt 0 ]; do
     case "${1}" in
         -h|--help|help)
-            usage
+            template_usage
             ;;
         -x|--debug)
             enable_debug

--- a/usr/local/libexec/rocinante/verify.sh
+++ b/usr/local/libexec/rocinante/verify.sh
@@ -124,7 +124,7 @@ verify_template() {
 while [ "$#" -gt 0 ]; do
     case "${1}" in
         -h|--help|help)
-            usage
+            verify_usage
             ;;
         -x|--debug)
             enable_debug


### PR DESCRIPTION
The current design for -h|--help|help is command_usage rather than just usage.